### PR TITLE
Adding ability to promote the DEV image to STAGE

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,18 @@ Argo CD continuously monitor the configurations stored in the Git repository and
     $ tkn pipeline logs petclinic-deploy-dev -n NAMESPACE
     ```
 
+1. To promote your current DEV stuff to STAGE, run the following:
+   
+   ```
+   $ demo.sh promote 
+   ```
+
+   This will get the current DIGEST of the running IMAGE and will change the kustomize.yaml file 
+   accordingly.
+
+   It will then push the changes to `spring-petclinic-config` Git repository on Gogs.
+
+   
 ![Pipeline Diagram](docs/images/pipeline-viz.png)
 
 ![Argo CD](docs/images/argocd.png)

--- a/argo/kustomization.yaml
+++ b/argo/kustomization.yaml
@@ -1,5 +1,7 @@
 resources:
-- argocd.yaml
+# we are not going to create our own argocd cluster here. 
+# We are going to use openshift-gitops one
+#- argocd.yaml
 - argocd-petclinic-project.yaml
 - argocd-app-dev.yaml
 - argocd-app-stage.yaml

--- a/demo.sh
+++ b/demo.sh
@@ -45,6 +45,7 @@ declare -r dev_prj="$PRJ_PREFIX-dev"
 declare -r stage_prj="$PRJ_PREFIX-stage"
 declare -r cicd_prj="$PRJ_PREFIX-cicd"
 
+
 command.help() {
   cat <<-EOF
 
@@ -63,6 +64,7 @@ command.help() {
 
   OPTIONS:
       -p|--project-prefix [string]   Prefix to be added to demo project names e.g. PREFIX-dev
+      
 EOF
 }
 
@@ -126,8 +128,8 @@ spec:
     repoURL: http://$GOGS_HOSTNAME/gogs/spring-petclinic-config
 EOF
   oc apply -k argo -n $cicd_prj
-  oc policy add-role-to-user admin system:serviceaccount:$cicd_prj:argocd-argocd-application-controller -n $dev_prj
-  oc policy add-role-to-user admin system:serviceaccount:$cicd_prj:argocd-argocd-application-controller -n $stage_prj
+  oc policy add-role-to-user admin system:serviceaccount:openshift-gitops:openshift-gitops-argocd-application-controller -n $dev_prj
+  oc policy add-role-to-user admin system:serviceaccount:openshift-gitops:openshift-gitops-argocd-application-controller -n $stage_prj
 
   oc project $cicd_prj
 
@@ -155,7 +157,7 @@ EOF
   Gogs Git Server: http://$GOGS_HOSTNAME/explore/repos
   SonarQube: https://$(oc get route sonarqube -o template --template='{{.spec.host}}' -n $cicd_prj)
   Sonatype Nexus: http://$(oc get route nexus -o template --template='{{.spec.host}}' -n $cicd_prj)
-  Argo CD:  http://$(oc get route argocd-server -o template --template='{{.spec.host}}' -n $cicd_prj)  [admin pwd: $(oc get secret argocd-cluster -n $cicd_prj -ojsonpath='{.data.admin\.password}' | base64 -d)]
+  Argo CD:  http://$(oc get route openshift-gitops-server -o template --template='{{.spec.host}}' -n openshift-gitops)  [admin pwd: $(oc get secret openshift-gitops-cluster -n openshift-gitops -ojsonpath='{.data.admin\.password}' | base64 -d)]
 
 ############################################################################
 ############################################################################


### PR DESCRIPTION
Added a new function in demo.sh which will start promoting the current image in DEV to STAGE project. For this it does the following steps:

- Getting full image description out of the current Deployment from DEV
- Cutting out IMAGE and DIGEST from the description
- Clones the `spring-petclinic-config`repository from Gogs
- Tags the IMAGE to `testing`
- Creates a `customization.yaml` file for STAGE environment with updated IMAGE and DIGEST infos
- Commits the work

