### PR TITLE
Adding PVC to pipeline-build-run

### DIFF
--- a/runs/pipeline-build-run.yaml
+++ b/runs/pipeline-build-run.yaml
@@ -6,9 +6,15 @@ spec:
   pipelineRef:
     name: petclinic-build
   workspaces:
-  - name: workspace
-    persistentVolumeClaim:
-      claimName: petclinic-build-workspace
+    - name: workspace
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 5Gi
+          storageClassName: gp2
   - name: maven-settings
     configMap:
       name: maven-settings

--- a/runs/pipeline-build-run.yaml
+++ b/runs/pipeline-build-run.yaml
@@ -6,15 +6,15 @@ spec:
   pipelineRef:
     name: petclinic-build
   workspaces:
-    - name: workspace
-      volumeClaimTemplate:
-        spec:
-          accessModes:
-            - ReadWriteOnce
-          resources:
-            requests:
-              storage: 5Gi
-          storageClassName: gp2
+  - name: workspace
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 5Gi
+        storageClassName: gp2
   - name: maven-settings
     configMap:
       name: maven-settings


### PR DESCRIPTION
Because we removed pvc in favor of volume claim template in triggertemplate; we will need to add a PVC in the pipeline-build-run so that when you run './demo start' it will not fail